### PR TITLE
fix time overflow bug

### DIFF
--- a/front-end/src/components/Main.vue
+++ b/front-end/src/components/Main.vue
@@ -89,7 +89,7 @@ function getArriveTime(minutes: number){
   let date = new Date();
   let time_now = date.getHours() * 60 + date.getMinutes();
   let time_arrive = time_now + minutes
-  if(time_arrive > 23 * 60 + 30){
+  if(time_arrive > 23 * 60 + 30 || (time_arrive % 24 * 60) < 6 * 60){
     ElMessage.warning("列车不在此时段运营，请注意时间")
   }
   if(Math.floor(time_arrive / 60) > 24){


### PR DESCRIPTION
我添加了一个if语句用来判断时间是否溢出
```
if(Math.floor(time_arrive / 60) > 24){
    return ("明日" + Math.floor(time_arrive /60 - 24)  + ":" + ((time_arrive % 60) < 10 ? "0" + (time_arrive % 60) : (time_arrive % 60)))
  } else {
    return (Math.floor(time_arrive / 60) + ":" + ((time_arrive % 60) < 10 ? "0" + (time_arrive % 60) : (time_arrive % 60)));
  }
```